### PR TITLE
Fixed comments color

### DIFF
--- a/Dracula.xml
+++ b/Dracula.xml
@@ -46,7 +46,7 @@
 					<value name="PopTextColorIdx" type="hex" data="10"/>
 					<value name="PopBackColorIdx" type="hex" data="10"/>
 					<value name="ColorTable00" type="dword" data="00362a28"/>
-					<value name="ColorTable01" type="dword" data="00362a28"/>
+					<value name="ColorTable01" type="dword" data="00cc6374"/>
 					<value name="ColorTable02" type="dword" data="00f993bd"/>
 					<value name="ColorTable03" type="dword" data="00fde98b"/>
 					<value name="ColorTable04" type="dword" data="005555ff"/>


### PR DESCRIPTION
ColorTable01 property updated to make code comments visible in terminal.

BEFORE
![image](https://github.com/dracula/cmder/assets/22408258/7e610b4c-3aa5-4cf9-afc0-f34e3bb7f7a7)

AFTER
![image](https://github.com/dracula/cmder/assets/22408258/44f95d9e-c55f-4d0a-a8bc-12c970d90166)